### PR TITLE
Engine now returns violations per repo instead of per org

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Each violation has the following structure:
   "policy_id": string,
   "description": string,
   "severity": "high" | "medium" | "low",
+  "repo_name": "myorg/public-repo",
   "details": {
     "key": "value",
     "foo": "bar"
@@ -121,7 +122,7 @@ These policies ensure repositories follow basic security best practices:
 
 | Policy ID                   | Description                                   | Severity | Details                                           |
 | --------------------------- | --------------------------------------------- | -------- | ------------------------------------------------- |
-| `REPO_NO_PUBLIC_001`        | Public repositories are not allowed           | High     | Repository name, current/required visibility      |
+| `REPO_NO_PUBLIC`            | Public repositories are not allowed           | High     | Repository name, current/required visibility      |
 | `REPO_NO_MISSING_ADMIN`     | Repositories must have at least one admin     | High     | Repository name, admin count, total collaborators |
 | `REPO_NO_RESTRICTED_ADMINS` | Restricted users should not have admin access | High     | Repository name, user, current/max permissions    |
 
@@ -135,9 +136,9 @@ Identifies public repositories
 {
   "policy_id": "REPO_NO_PUBLIC_001",
   "description": "Public repositories are not allowed",
+  "repo_name": "myorg/public-repo",
   "severity": "high",
   "details": {
-    "repository": "myorg/public-repo",
     "current_visibility": "public",
     "required_visibility": "private"
   }

--- a/api/v1/github_scanner.proto
+++ b/api/v1/github_scanner.proto
@@ -38,8 +38,7 @@ message Collaborator {
   string github_id = 1;
   string login = 2; // GitHub username
   string type = 3; // Type of user (e.g., "User", "Organization", "Bot")
-  string html_url = 4;
-  string permission = 5; // Highest permission level the collaborator has (e.g., "admin", "push", "pull")
+  string permission = 4; // Highest permission level the collaborator has (e.g., "admin", "push", "pull")
 }
 
 // TeamAccess represents a GitHub team's permission level on a repository.

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -166,9 +166,9 @@ func (pe *PolicyEngine) parseViolation(violationMap map[string]interface{}) (Pol
 		return PolicyViolation{}, fmt.Errorf("severity is missing or not a string")
 	}
 
-	repoName, ok := violationMap["repoName"].(string)
+	repoName, ok := violationMap["repo_name"].(string)
 	if !ok {
-		return PolicyViolation{}, fmt.Errorf("repoName is missing or not a string")
+		return PolicyViolation{}, fmt.Errorf("repo_name is missing or not a string")
 	}
 
 	violation := PolicyViolation{

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -15,6 +15,7 @@ type PolicyViolation struct {
 	PolicyID    string            `json:"policy_id"`
 	Description string            `json:"description"`
 	Severity    string            `json:"severity"`
+	RepoName    string            `json:"repo_name"`
 	Details     map[string]string `json:"details"`
 }
 
@@ -51,18 +52,18 @@ func NewPolicyEngine(policyDir string) (*PolicyEngine, error) {
 }
 
 // EvaluateOrganization evaluates the organization data against all loaded policies
-func (pe *PolicyEngine) EvaluateOrganization(ctx context.Context, orgData normalizer.OrganizationData) ([]PolicyViolation, error) {
+func (pe *PolicyEngine) EvaluateOrganization(ctx context.Context, orgData normalizer.OrganizationData) (map[string][]PolicyViolation, error) {
 	log.Printf("Evaluating organization: %s", orgData.Name)
 
 	var allViolations []PolicyViolation
 
 	// Evaluate repository security policies
-	repoViolations, err := pe.preparedQuery.Eval(ctx, rego.EvalInput(orgData))
+	orgViolations, err := pe.preparedQuery.Eval(ctx, rego.EvalInput(orgData))
 	if err != nil {
 		return nil, fmt.Errorf("failed to evaluate repository security policies: %w", err)
 	}
 
-	for _, v := range repoViolations {
+	for _, v := range orgViolations {
 		violation, err := pe.parseViolations(v)
 		if err != nil {
 			log.Printf("Warning: failed to parse violation: %v", err)
@@ -72,7 +73,17 @@ func (pe *PolicyEngine) EvaluateOrganization(ctx context.Context, orgData normal
 	}
 	log.Printf("Repository security policy evaluation returned %d violations", len(allViolations))
 
-	return allViolations, nil
+	// Format violations by repository
+	violationsMap := make(map[string][]PolicyViolation)
+	for _, violation := range allViolations {
+		if violation.RepoName == "" {
+			log.Printf("Warning: violation %s has no repository name, skipping", violation.PolicyID)
+			continue
+		}
+		violationsMap[violation.RepoName] = append(violationsMap[violation.RepoName], violation)
+	}
+
+	return violationsMap, nil
 }
 
 // parseViolations converts OPA result to PolicyViolation structs
@@ -155,10 +166,16 @@ func (pe *PolicyEngine) parseViolation(violationMap map[string]interface{}) (Pol
 		return PolicyViolation{}, fmt.Errorf("severity is missing or not a string")
 	}
 
+	repoName, ok := violationMap["repoName"].(string)
+	if !ok {
+		return PolicyViolation{}, fmt.Errorf("repoName is missing or not a string")
+	}
+
 	violation := PolicyViolation{
 		PolicyID:    policyID,
 		Description: description,
 		Severity:    severity,
+		RepoName:    repoName,
 		Details:     make(map[string]string),
 	}
 

--- a/policies/repository_security.rego
+++ b/policies/repository_security.rego
@@ -9,10 +9,10 @@ deny contains violation if {
     repo.private == false
     violation := {
         "policy_id": "REPO_NO_PUBLIC_001",
+        "repo_name": repo.full_name,
         "description": "Public repositories are not allowed",
         "severity": "high",
         "details": {
-            "repository": repo.full_name,
             "current_visibility": "public",
             "required_visibility": "private"
         }
@@ -29,10 +29,10 @@ deny contains violation if {
     count(admins) < min_admins
     violation := {
         "policy_id": "REPO_NO_MISSING_ADMIN",
+        "repo_name": repo.full_name,
         "description": "Repository does not have enough admins",
         "severity": "high",
         "details": {
-            "repository": repo.full_name,
             "admin_count": sprintf("%d", [count(admins)]),
             "required_min_admins": sprintf("%d", [min_admins]),
             "total_collaborators": sprintf("%d", [count(access.collaborators)])
@@ -50,10 +50,10 @@ deny contains violation if {
     is_restricted_user(collaborator.login)
     violation := {
         "policy_id": "REPO_NO_RESTRICTED_ADMINS",
+        "repo_name": repo.full_name,
         "description": "Restricted users should not have admin access",
         "severity": "high",
         "details": {
-            "repository": repo.full_name,
             "user": collaborator.login,
             "current_permission": collaborator.permission,
             "max_allowed_permission": "pull"


### PR DESCRIPTION
Introduces a change where instead of having the `engine` return a list of violations, it returns **a map** where each key is a repo name and the value is an array of violations related to this repo